### PR TITLE
exchange the filenames of durable_epoch

### DIFF
--- a/src/recovery/logger.cpp
+++ b/src/recovery/logger.cpp
@@ -37,8 +37,8 @@ namespace LineairDB {
 namespace Recovery {
 
 Logger::Logger(const Config& config)
-    : DurableEpochNumberFileName(config.lineairdb_logs_dir + "/durable_epoch_working.json"),
-      DurableEpochNumberWorkingFileName(config.lineairdb_logs_dir + "/durable_epoch.json"),
+    : DurableEpochNumberFileName(config.lineairdb_logs_dir + "/durable_epoch.json"),
+      DurableEpochNumberWorkingFileName(config.lineairdb_logs_dir + "/durable_epoch.working.json"),
       WorkingDir(config.lineairdb_logs_dir),
       durable_epoch_(0),
       durable_epoch_working_file_(DurableEpochNumberWorkingFileName, std::ofstream::trunc) {


### PR DESCRIPTION
ref: https://github.com/LineairDB/LineairDB/pull/266#pullrequestreview-885570369

The file names were reversed, which caused an error in CI. (https://github.com/LineairDB/LineairDB/runs/4878727724?check_suite_focus=true)

Specifically, the test measures the size of all files in the log directory without "working" in the file name.
However, after "durable_epoch.json" is found and before the file size is measured, `rename` interleaves, and thus `durable_epoch.json` is renamed to `…working.json`.
This caused ENOENT of `durable_epoch.json`.